### PR TITLE
Use wss when behind a ssl terminating reverse proxy

### DIFF
--- a/hogwatch/server/static/js/main.js
+++ b/hogwatch/server/static/js/main.js
@@ -103,13 +103,9 @@ function seriesBlueprint(mode){
 //to get all devices GET /interfaces  :for now I am just using all available interfaces
 var defaultInterfaces=['all'];
 
-function getSocketURL(interface_list,mode){
-    var host=location.host;
-    if (location.protocol === 'https:') {
-        return socketURL='wss://'+host+'/websocket/'+interface_list.join('_')+'/'+mode;
-    } else {
-        return socketURL='ws://'+host+'/websocket/'+interface_list.join('_')+'/'+mode;
-    }
+function getSocketURL(interface_list, mode) {
+    var socketProtocol = location.protocol === 'https:' ? 'wss://' : 'ws://';
+    return socketProtocol + location.host + '/websocket/' + interface_list.join('_') + '/' + mode;
 }
 
 if ("WebSocket" in window){

--- a/hogwatch/server/static/js/main.js
+++ b/hogwatch/server/static/js/main.js
@@ -104,9 +104,12 @@ function seriesBlueprint(mode){
 var defaultInterfaces=['all'];
 
 function getSocketURL(interface_list,mode){
-    var host=location.host;    
-    var socketURL='ws://'+host+'/websocket/'+interface_list.join('_')+'/'+mode;
-    return socketURL;    
+    var host=location.host;
+    if (location.protocol === 'https:') {
+        return socketURL='wss://'+host+'/websocket/'+interface_list.join('_')+'/'+mode;
+    } else {
+        return socketURL='ws://'+host+'/websocket/'+interface_list.join('_')+'/'+mode;
+    }
 }
 
 if ("WebSocket" in window){


### PR DESCRIPTION
Automatically switch to secure websockets if behind a ssl proxy. (Fixing mixed content errors)